### PR TITLE
T159 floor

### DIFF
--- a/loggins/loggins/urls.py
+++ b/loggins/loggins/urls.py
@@ -35,6 +35,7 @@ urlpatterns += patterns('ui.views',
     # code should be something like 'g2' for Gelman 2nd floor
     url(r'^floor/(?P<code>[a-z|A-Z][0-9])/$', 'floor', name='floor'),
     # offline carrels
+    url(r'^(?i)offline/$', 'offline', {'library': 'all'}, name='offline'),
     url(r'^(?i)gelman/offline$', 'offline', {'library': 'gelman'}, name='gelman-offline'),
     url(r'^(?i)eckles/offline$', 'offline', {'library': 'eckles'}, name='eckles-offline'),
     url(r'^(?i)vstc/offline$', 'offline', {'library': 'vstc'}, name='vstc-offline'),

--- a/loggins/loggins/urls.py
+++ b/loggins/loggins/urls.py
@@ -30,14 +30,17 @@ urlpatterns += patterns('ui.views',
     # "or" match can be specified with r'^(?P<library>gelman|eckles|
     # vstc)/(?P<floor>[0-9])/$'
     #(?i) = case insensitive match
+    # example:  gelman
     url(r'^(?P<library>(?i)(%s)?)/$' % buildings_or, 'home', name='home'),
-    # example:  location/g2/PC101   for PC101 on Gelman 2nd floor
-    url(r'^location/(?P<bldgfloorcode>[a-z|A-Z][0-9])/(?P<station>[0-9|a-z|A-Z]-[L|l|0-9]+)/$',
+    # example:  location/gelman/PC101   for PC101 in Gelman
+    url(r'^location/(?P<library>(?i)(%s)?)/(?P<station>[0-9|a-z|A-Z]-[L|l|0-9]+)/$' % buildings_or,
         'location', name='location'),
-    # code should be something like 'g2' for Gelman 2nd floor
-    url(r'^floor/(?P<code>[a-z|A-Z][0-9])/$', 'floor', name='floor'),
-    # offline carrels
+    # example:  gelman/floor/2
+    url(r'^(?P<library>(?i)(%s)?)/floor/(?P<floor_number>[0-9])/$$' % buildings_or, 'floor', name='floor'),
+    # all offline carrels
     url(r'^(?i)offline/$', 'offline', {'library': 'all'}, name='offline'),
+    # example:  gelman/offline
     url(r'^(?P<library>(?i)(%s)?)/offline/$' % buildings_or, 'offline', name='offline'),
+    # example:  gelman/sign/250
     url(r'^(?P<library>(?i)(%s)?)/sign/(?P<width>[0-9]+)/$' % buildings_or, 'home', name='sign'),
 )

--- a/loggins/loggins/urls.py
+++ b/loggins/loggins/urls.py
@@ -33,7 +33,7 @@ urlpatterns += patterns('ui.views',
     # example:  gelman
     url(r'^(?P<library>(?i)(%s)?)/$' % buildings_or, 'home', name='home'),
     # example:  location/gelman/PC101   for PC101 in Gelman
-    url(r'^location/(?P<library>(?i)(%s)?)/(?P<station>[0-9|a-z|A-Z]-[L|l|0-9]+)/$' % buildings_or,
+    url(r'^(?P<library>(?i)(%s)?)/location/(?P<station>[0-9|a-z|A-Z]-[L|l|0-9]+)/$' % buildings_or,
         'location', name='location'),
     # example:  gelman/floor/2
     url(r'^(?P<library>(?i)(%s)?)/floor/(?P<floor_number>[0-9])/$$' % buildings_or, 'floor', name='floor'),

--- a/loggins/loggins/urls.py
+++ b/loggins/loggins/urls.py
@@ -36,7 +36,7 @@ urlpatterns += patterns('ui.views',
     url(r'^(?P<library>(?i)(%s)?)/location/(?P<station>[0-9|a-z|A-Z]-[L|l|0-9]+)/$' % buildings_or,
         'location', name='location'),
     # example:  gelman/floor/2
-    url(r'^(?P<library>(?i)(%s)?)/floor/(?P<floor_number>[0-9])/$$' % buildings_or, 'floor', name='floor'),
+    url(r'^(?P<library>(?i)(%s)?)/floor/(?P<floor_number>[0-9])/$' % buildings_or, 'floor', name='floor'),
     # all offline carrels
     url(r'^(?i)offline/$', 'offline', {'library': 'all'}, name='offline'),
     # example:  gelman/offline

--- a/loggins/loggins/urls.py
+++ b/loggins/loggins/urls.py
@@ -5,12 +5,16 @@ from django.views.generic import TemplateView
 from tastypie.api import Api
 
 from ui.api import LocationResource, SessionResource
+from ui.models import Building
 
 admin.autodiscover()
 
 api_1 = Api(api_name='v1')
 api_1.register(LocationResource())
 api_1.register(SessionResource())
+
+buildings = map(str, Building.objects.values_list('name', flat=True))
+buildings_or = '|'.join(buildings)
 
 urlpatterns = patterns('',
     url(r'^api/', include(api_1.urls)),
@@ -26,9 +30,7 @@ urlpatterns += patterns('ui.views',
     # "or" match can be specified with r'^(?P<library>gelman|eckles|
     # vstc)/(?P<floor>[0-9])/$'
     #(?i) = case insensitive match
-    url(r'^(?i)gelman/$', 'home', {'library': 'gelman'}, name='gelman-home'),
-    url(r'^(?i)eckles/$', 'home', {'library': 'eckles'}, name='eckles-home'),
-    url(r'^(?i)vstc/$', 'home', {'library': 'vstc'}, name='vstc-home'),
+    url(r'^(?P<library>(?i)(%s)?)/$' % buildings_or, 'home', name='home'),
     # example:  location/g2/PC101   for PC101 on Gelman 2nd floor
     url(r'^location/(?P<bldgfloorcode>[a-z|A-Z][0-9])/(?P<station>[0-9|a-z|A-Z]-[L|l|0-9]+)/$',
         'location', name='location'),
@@ -36,10 +38,6 @@ urlpatterns += patterns('ui.views',
     url(r'^floor/(?P<code>[a-z|A-Z][0-9])/$', 'floor', name='floor'),
     # offline carrels
     url(r'^(?i)offline/$', 'offline', {'library': 'all'}, name='offline'),
-    url(r'^(?i)gelman/offline$', 'offline', {'library': 'gelman'}, name='gelman-offline'),
-    url(r'^(?i)eckles/offline$', 'offline', {'library': 'eckles'}, name='eckles-offline'),
-    url(r'^(?i)vstc/offline$', 'offline', {'library': 'vstc'}, name='vstc-offline'),
-    url(r'^(?i)gelman/sign/(?P<width>[0-9]+)[/?]$', 'home', {'library': 'gelman'}, name='gelman-sign'),
-    url(r'^(?i)eckles/sign/(?P<width>[0-9]+)[/?]$', 'home', {'library': 'eckles'}, name='eckles-sign'),
-    url(r'^(?i)vstc/sign/(?P<width>[0-9]+)[/?]$', 'home', {'library': 'vstc'}, name='vstc-sign'),
+    url(r'^(?P<library>(?i)(%s)?)/offline/$' % buildings_or, 'offline', name='offline'),
+    url(r'^(?P<library>(?i)(%s)?)/sign/(?P<width>[0-9]+)/$' % buildings_or, 'home', name='sign'),
 )

--- a/loggins/ui/admin.py
+++ b/loggins/ui/admin.py
@@ -1,5 +1,4 @@
 from tastypie.admin import ApiKeyInline
-from tastypie.models import ApiAccess, ApiKey
 
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
@@ -33,8 +32,9 @@ admin.site.register(models.Zone, ZoneAdmin)
 
 
 class LocationAdmin(admin.ModelAdmin):
-    list_display = ['id', 'building', 'floor', 'zone', 'station_name', 'hostname',
-                    'ip_address', 'os', 'state', 'observation_time']
+    list_display = ['id', 'building', 'floor', 'zone', 'station_name',
+                    'hostname', 'ip_address', 'os', 'state',
+                    'observation_time']
     list_filter = ['building']
     search_fields = ['station_name']
 admin.site.register(models.Location, LocationAdmin)

--- a/loggins/ui/admin.py
+++ b/loggins/ui/admin.py
@@ -14,8 +14,26 @@ admin.site.unregister(User)
 admin.site.register(User, UserModelAdmin)
 
 
+class BuildingAdmin(admin.ModelAdmin):
+    list_display = ['id', 'name']
+admin.site.register(models.Building, BuildingAdmin)
+
+
+class FloorAdmin(admin.ModelAdmin):
+    list_display = ['id', 'floor', 'building']
+    list_filter = ['building__name']
+    ordering = ['building__name', 'floor']
+admin.site.register(models.Floor, FloorAdmin)
+
+
+class ZoneAdmin(admin.ModelAdmin):
+    list_display = ['id', 'name', 'floor', 'display_order']
+    list_editable = ['name', 'floor', 'display_order']
+admin.site.register(models.Zone, ZoneAdmin)
+
+
 class LocationAdmin(admin.ModelAdmin):
-    list_display = ['id', 'building', 'floor', 'station_name', 'hostname',
+    list_display = ['id', 'building', 'floor', 'zone', 'station_name', 'hostname',
                     'ip_address', 'os', 'state', 'observation_time']
     list_filter = ['building']
     search_fields = ['station_name']

--- a/loggins/ui/admin.py
+++ b/loggins/ui/admin.py
@@ -32,17 +32,18 @@ admin.site.register(models.Zone, ZoneAdmin)
 
 
 class LocationAdmin(admin.ModelAdmin):
-    list_display = ['id', 'building', 'floor', 'zone', 'station_name',
+    list_display = ['id', 'zone', 'station_name',
                     'hostname', 'ip_address', 'os', 'state',
                     'observation_time']
-    list_filter = ['building']
+    #list_filter = ['building']
+    ordering = ['id']
     search_fields = ['station_name']
 admin.site.register(models.Location, LocationAdmin)
 
 
 class DurationFilter(admin.SimpleListFilter):
-    title = 'duration'
-    parameter_name = 'duration'
+    title = 'duration_minutes'
+    parameter_name = 'duration_minutes'
 
     def lookups(self, request, model_admin):
         return [('0-5', '0-5'),

--- a/loggins/ui/api.py
+++ b/loggins/ui/api.py
@@ -11,6 +11,10 @@ from ui.models import Location, Session
 
 
 class LocationResource(ModelResource):
+    building_name = fields.CharField(attribute='building_name', readonly=True)
+    floor_number = fields.IntegerField(attribute='floor_number', readonly=True)
+    zone_name = fields.CharField(attribute='zone_name', readonly=True)
+
     class Meta:
         queryset = Location.objects.all()
         resource_name = 'location'
@@ -20,21 +24,22 @@ class LocationResource(ModelResource):
         filtering = {
             'hostname': ALL,
             'state': ALL,
-            'floor': ALL,
-            'building': ALL_WITH_RELATIONS,
             'os': ALL_WITH_RELATIONS,
             'station_name': ALL_WITH_RELATIONS,
             'ip_address': 'exact',
         }
-
+    """
     def prepend_urls(self):
         return [
             url(r"^(?P<resource_name>%s)/(?P<hostname>.+)/$" % self._meta.resource_name, self.wrap_view('dispatch_detail'), name="api_dispatch_detail"),
         ]
+    """
 
 
 class SessionResource(ModelResource):
     location = fields.ForeignKey(LocationResource, 'location')
+    duration_minutes = fields.FloatField(attribute='duration_minutes',
+                                         readonly=True)
 
     class Meta:
         queryset = Session.objects.all()
@@ -47,4 +52,5 @@ class SessionResource(ModelResource):
             'session_type': ALL,
             'timestamp_start': ALL,
             'timestamp_end': ALL,
+            'duration_minutes': ALL,
         }

--- a/loggins/ui/migrations/0004_auto__add_zone__add_floor__add_building__add_field_location_zone.py
+++ b/loggins/ui/migrations/0004_auto__add_zone__add_floor__add_building__add_field_location_zone.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'Zone'
+        db.create_table(u'ui_zone', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('name', self.gf('django.db.models.fields.CharField')(max_length=50, db_index=True)),
+            ('display_order', self.gf('django.db.models.fields.PositiveSmallIntegerField')()),
+            ('floor', self.gf('django.db.models.fields.related.ForeignKey')(related_name='floors', to=orm['ui.Floor'])),
+        ))
+        db.send_create_signal(u'ui', ['Zone'])
+
+        # Adding model 'Floor'
+        db.create_table(u'ui_floor', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('floor', self.gf('django.db.models.fields.PositiveSmallIntegerField')()),
+            ('building', self.gf('django.db.models.fields.related.ForeignKey')(related_name='buildings', to=orm['ui.Building'])),
+        ))
+        db.send_create_signal(u'ui', ['Floor'])
+
+        # Adding model 'Building'
+        db.create_table(u'ui_building', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('name', self.gf('django.db.models.fields.CharField')(max_length=50, db_index=True)),
+        ))
+        db.send_create_signal(u'ui', ['Building'])
+
+        # Adding field 'Location.zone'
+        db.add_column(u'ui_location', 'zone',
+                      self.gf('django.db.models.fields.related.ForeignKey')(related_name='zones', null=True, to=orm['ui.Zone']),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting model 'Zone'
+        db.delete_table(u'ui_zone')
+
+        # Deleting model 'Floor'
+        db.delete_table(u'ui_floor')
+
+        # Deleting model 'Building'
+        db.delete_table(u'ui_building')
+
+        # Deleting field 'Location.zone'
+        db.delete_column(u'ui_location', 'zone_id')
+
+
+    models = {
+        u'ui.building': {
+            'Meta': {'object_name': 'Building'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'})
+        },
+        u'ui.floor': {
+            'Meta': {'object_name': 'Floor'},
+            'building': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'buildings'", 'to': u"orm['ui.Building']"}),
+            'floor': ('django.db.models.fields.PositiveSmallIntegerField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        u'ui.location': {
+            'Meta': {'object_name': 'Location'},
+            'building': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '2', 'db_index': 'True'}),
+            'floor': ('django.db.models.fields.PositiveSmallIntegerField', [], {}),
+            'hostname': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ip_address': ('django.db.models.fields.GenericIPAddressField', [], {'db_index': 'True', 'max_length': '39', 'null': 'True', 'blank': 'True'}),
+            'last_login_start_time': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'last_offline_start_time': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'observation_time': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'os': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '4', 'db_index': 'True', 'blank': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'default': "'n'", 'max_length': '2', 'db_index': 'True'}),
+            'station_name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'}),
+            'zone': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'zones'", 'null': 'True', 'to': u"orm['ui.Zone']"})
+        },
+        u'ui.session': {
+            'Meta': {'object_name': 'Session'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'location': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'locations'", 'to': u"orm['ui.Location']"}),
+            'session_type': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '2', 'db_index': 'True'}),
+            'timestamp_end': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True'}),
+            'timestamp_start': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True'})
+        },
+        u'ui.zone': {
+            'Meta': {'object_name': 'Zone'},
+            'display_order': ('django.db.models.fields.PositiveSmallIntegerField', [], {}),
+            'floor': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'floors'", 'to': u"orm['ui.Floor']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'})
+        }
+    }
+
+    complete_apps = ['ui']

--- a/loggins/ui/migrations/0005_floors_zones.py
+++ b/loggins/ui/migrations/0005_floors_zones.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models
+
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        # try to find the entrance floor lab zone and
+        # entrance floor non-lab zone
+        labzone = orm.Zone.objects.get(floor__building__name='Gelman',
+                                       floor__floor=2, name__contains="Lab")
+        entrancemainzone = orm.Zone.objects.filter(
+            floor__building__name='Gelman', floor__floor=2). \
+            exclude(name__contains="Lab")[0]
+
+        # for each location, find the (first) matching zone
+        # by building and floor number.
+        for location in orm.Location.objects.all():
+            buildingname = {'g': 'Gelman', 'e': 'Eckles',
+                            'v': 'VSTC'}[location.building]
+            # special case for Gelman Entrance Floor
+            if location.building == 'g' and 'E-' in location.station_name:
+                if 'E-L' in location.station_name:
+                    zone = labzone
+                else:
+                    zone = entrancemainzone
+            # all others
+            else:
+                try:
+                    zone = orm.Zone.objects.filter(
+                        floor__building__name=buildingname,
+                        floor__floor=location.floor)[0]
+                except Exception:
+                    print("%s --  NO ZONE MATCHED; stopping." %
+                          location.station_name)
+                    raise
+
+            print("%s --  zone = %s %s %s" % (location.station_name,
+                                              zone.name,
+                                              zone.floor.building.name,
+                                              zone.floor.floor))
+            location.zone = zone
+            location.save()
+
+    def backwards(self, orm):
+        "Write your backwards methods here."
+
+    models = {
+        u'ui.building': {
+            'Meta': {'object_name': 'Building'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'})
+        },
+        u'ui.floor': {
+            'Meta': {'object_name': 'Floor'},
+            'building': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'buildings'", 'to': u"orm['ui.Building']"}),
+            'floor': ('django.db.models.fields.PositiveSmallIntegerField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        u'ui.location': {
+            'Meta': {'object_name': 'Location'},
+            'building': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '2', 'db_index': 'True'}),
+            'floor': ('django.db.models.fields.PositiveSmallIntegerField', [], {}),
+            'hostname': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ip_address': ('django.db.models.fields.GenericIPAddressField', [], {'db_index': 'True', 'max_length': '39', 'null': 'True', 'blank': 'True'}),
+            'last_login_start_time': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'last_offline_start_time': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'observation_time': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'os': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '4', 'db_index': 'True', 'blank': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'default': "'n'", 'max_length': '2', 'db_index': 'True'}),
+            'station_name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'}),
+            'zone': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'zones'", 'null': 'True', 'to': u"orm['ui.Zone']"})
+        },
+        u'ui.session': {
+            'Meta': {'object_name': 'Session'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'location': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'locations'", 'to': u"orm['ui.Location']"}),
+            'session_type': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '2', 'db_index': 'True'}),
+            'timestamp_end': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True'}),
+            'timestamp_start': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True'})
+        },
+        u'ui.zone': {
+            'Meta': {'object_name': 'Zone'},
+            'display_order': ('django.db.models.fields.PositiveSmallIntegerField', [], {}),
+            'floor': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'floors'", 'to': u"orm['ui.Floor']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'})
+        }
+    }
+
+    complete_apps = ['ui']
+    symmetrical = True

--- a/loggins/ui/migrations/0005_floors_zones.py
+++ b/loggins/ui/migrations/0005_floors_zones.py
@@ -8,6 +8,81 @@ from django.db import models
 class Migration(DataMigration):
 
     def forwards(self, orm):
+        # ---- POPULATE WITH NEW GWLIBRARY BUILDINGS, FLOORS, ZONES ----
+        building_gelman = orm.Building(name='Gelman')
+        building_gelman.save()
+        building_eckles = orm.Building(name='Eckles')
+        building_eckles.save()
+        building_vstc = orm.Building(name='VSTC')
+        building_vstc.save()
+
+        floor_gelman0 = orm.Floor(floor=0, building=building_gelman)
+        floor_gelman0.save()
+        floor_gelman1 = orm.Floor(floor=1, building=building_gelman)
+        floor_gelman1.save()
+        floor_gelman2 = orm.Floor(floor=2, building=building_gelman)
+        floor_gelman2.save()
+        floor_gelman3 = orm.Floor(floor=3, building=building_gelman)
+        floor_gelman3.save()
+        floor_gelman4 = orm.Floor(floor=4, building=building_gelman)
+        floor_gelman4.save()
+        floor_gelman5 = orm.Floor(floor=5, building=building_gelman)
+        floor_gelman5.save()
+        floor_gelman6 = orm.Floor(floor=6, building=building_gelman)
+        floor_gelman6.save()
+        floor_gelman7 = orm.Floor(floor=7, building=building_gelman)
+        floor_gelman7.save()
+        floor_eckles1 = orm.Floor(floor=1, building=building_eckles)
+        floor_eckles1.save()
+        floor_eckles2 = orm.Floor(floor=2, building=building_eckles)
+        floor_eckles2.save()
+        floor_vstc1 = orm.Floor(floor=1, building=building_vstc)
+        floor_vstc1.save()
+
+        zone_gelmanll = orm.Zone(floor=floor_gelman0, name='Lower Level',
+                                 display_order=0)
+        zone_gelmanll.save()
+        zone_gelman1 = orm.Zone(floor=floor_gelman1, name='1st Floor',
+                                display_order=1)
+        zone_gelman1.save()
+        zone_gelmanentrance = orm.Zone(floor=floor_gelman2,
+                                       name='Entrance Floor',
+                                       display_order=2)
+        zone_gelmanentrance.save()
+        zone_gelmanlab = orm.Zone(floor=floor_gelman2,
+                                  name='Lab @ Entrance Floor',
+                                  display_order=3)
+        zone_gelmanlab.save()
+        zone_gelman3 = orm.Zone(floor=floor_gelman3, name='3rd Floor',
+                                display_order=4)
+        zone_gelman3.save()
+        zone_gelman4 = orm.Zone(floor=floor_gelman4, name='4th Floor',
+                                display_order=5)
+        zone_gelman4.save()
+        zone_gelman5 = orm.Zone(floor=floor_gelman5, name='5th Floor',
+                                display_order=6)
+        zone_gelman5.save()
+        zone_gelman6 = orm.Zone(floor=floor_gelman6, name='6th Floor',
+                                display_order=7)
+        zone_gelman6.save()
+        zone_gelmangrc = orm.Zone(floor=floor_gelman6,
+                                  name='Global Resources Center',
+                                  display_order=8)
+        zone_gelmangrc.save()
+        zone_gelman7 = orm.Zone(floor=floor_gelman7, name='7th Floor',
+                                display_order=9)
+        zone_gelman7.save()
+        zone_eckles1 = orm.Zone(floor=floor_eckles1, name='Eckles Main',
+                                display_order=0)
+        zone_eckles1.save()
+        zone_eckles2 = orm.Zone(floor=floor_eckles2, name='Eckles 2nd Floor',
+                                display_order=1)
+        zone_eckles2.save()
+        zone_vstc1 = orm.Zone(floor=floor_vstc1, name='VSTC Main',
+                              display_order=0)
+        zone_vstc1.save()
+
+        # ---- MAP OLD LOCATION DATA TO NEW OBJECTS ----
         # try to find the entrance floor lab zone and
         # entrance floor non-lab zone
         labzone = orm.Zone.objects.get(floor__building__name='Gelman',

--- a/loggins/ui/migrations/0005_floors_zones.py
+++ b/loggins/ui/migrations/0005_floors_zones.py
@@ -65,13 +65,13 @@ class Migration(DataMigration):
         zone_gelman6 = orm.Zone(floor=floor_gelman6, name='6th Floor',
                                 display_order=7)
         zone_gelman6.save()
-        zone_gelmangrc = orm.Zone(floor=floor_gelman6,
-                                  name='Global Resources Center',
-                                  display_order=8)
-        zone_gelmangrc.save()
         zone_gelman7 = orm.Zone(floor=floor_gelman7, name='7th Floor',
-                                display_order=9)
+                                display_order=8)
         zone_gelman7.save()
+        zone_gelmangrc = orm.Zone(floor=floor_gelman7,
+                                  name='Global Resources Center',
+                                  display_order=9)
+        zone_gelmangrc.save()
         zone_eckles1 = orm.Zone(floor=floor_eckles1, name='Eckles Main',
                                 display_order=0)
         zone_eckles1.save()

--- a/loggins/ui/migrations/0006_auto__del_field_location_building__del_field_location_floor.py
+++ b/loggins/ui/migrations/0006_auto__del_field_location_building__del_field_location_floor.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        user_verify = raw_input("*** WARNING *** This migration is irreverisble! Have you backed up your database (Y/N)? ")
+        if user_verify.lower() != 'y' and user_verify.lower() != 'yes':
+            print "Aborting. Please back up your database before running this migration."
+            raise RuntimeError("Cannot proceed until user indicates that database has been backed up.")
+
+        # Deleting field 'Location.building'
+        db.delete_column(u'ui_location', 'building')
+
+        # Deleting field 'Location.floor'
+        db.delete_column(u'ui_location', 'floor')
+
+
+    def backwards(self, orm):
+        # Adding field 'Location.building'
+        db.add_column(u'ui_location', 'building',
+                      self.gf('django.db.models.fields.CharField')(default='', max_length=2, db_index=True),
+                      keep_default=False)
+
+
+        # User chose to not deal with backwards NULL issues for 'Location.floor'
+        raise RuntimeError("Cannot reverse this migration. 'Location.floor' and its values cannot be restored.")
+        
+        # The following code is provided here to aid in writing a correct migration        # Adding field 'Location.floor'
+        db.add_column(u'ui_location', 'floor',
+                      self.gf('django.db.models.fields.PositiveSmallIntegerField')(),
+                      keep_default=False)
+
+
+    models = {
+        u'ui.building': {
+            'Meta': {'object_name': 'Building'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'})
+        },
+        u'ui.floor': {
+            'Meta': {'object_name': 'Floor'},
+            'building': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'buildings'", 'to': u"orm['ui.Building']"}),
+            'floor': ('django.db.models.fields.PositiveSmallIntegerField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        u'ui.location': {
+            'Meta': {'object_name': 'Location'},
+            'hostname': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ip_address': ('django.db.models.fields.GenericIPAddressField', [], {'db_index': 'True', 'max_length': '39', 'null': 'True', 'blank': 'True'}),
+            'last_login_start_time': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'last_offline_start_time': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'observation_time': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'os': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '4', 'db_index': 'True', 'blank': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'default': "'n'", 'max_length': '2', 'db_index': 'True'}),
+            'station_name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'}),
+            'zone': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'zones'", 'null': 'True', 'to': u"orm['ui.Zone']"})
+        },
+        u'ui.session': {
+            'Meta': {'object_name': 'Session'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'location': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'locations'", 'to': u"orm['ui.Location']"}),
+            'session_type': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '2', 'db_index': 'True'}),
+            'timestamp_end': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True'}),
+            'timestamp_start': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True'})
+        },
+        u'ui.zone': {
+            'Meta': {'object_name': 'Zone'},
+            'display_order': ('django.db.models.fields.PositiveSmallIntegerField', [], {}),
+            'floor': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'floors'", 'to': u"orm['ui.Floor']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'})
+        }
+    }
+
+    complete_apps = ['ui']

--- a/loggins/ui/models.py
+++ b/loggins/ui/models.py
@@ -10,6 +10,30 @@ from tastypie.models import create_api_key
 models.signals.post_save.connect(create_api_key, sender=User)
 
 
+class Building(models.Model):
+    name = models.CharField(max_length=50, db_index=True)
+
+    def __unicode__(self):
+        return '<Building %s>' % (self.name)
+
+
+class Floor(models.Model):
+    floor = models.PositiveSmallIntegerField()
+    building = models.ForeignKey(Building, related_name='buildings')
+
+    def __unicode__(self):
+        return '<Floor %s %d>' % (self.building.name, self.floor)
+
+
+class Zone(models.Model):
+    name = models.CharField(max_length=50, db_index=True)
+    display_order = models.PositiveSmallIntegerField()
+    floor = models.ForeignKey(Floor, related_name='floors')
+
+    def __unicode__(self):
+        return '<Zone %s %s %d>' % (self.name, self.floor.building.name, self.floor.floor)
+
+
 class Location(models.Model):
     GELMAN = 'g'
     ECKLES = 'e'
@@ -39,6 +63,7 @@ class Location(models.Model):
     building = models.CharField(db_index=True, max_length=2,
                                 choices=BUILDINGS, default='')
     floor = models.PositiveSmallIntegerField()
+    zone = models.ForeignKey(Zone, related_name='zones', null=True)
     # station name/number does not have to be unique across floors/buildings
     station_name = models.CharField(max_length=50, db_index=True)
     hostname = models.CharField(max_length=50, db_index=True)

--- a/loggins/ui/models.py
+++ b/loggins/ui/models.py
@@ -31,7 +31,8 @@ class Zone(models.Model):
     floor = models.ForeignKey(Floor, related_name='floors')
 
     def __unicode__(self):
-        return '<Zone %s %s %d>' % (self.name, self.floor.building.name, self.floor.floor)
+        return '<Zone %s %s %d>' % (self.name, self.floor.building.name,
+                                    self.floor.floor)
 
 
 class Location(models.Model):

--- a/loggins/ui/templates/404.html
+++ b/loggins/ui/templates/404.html
@@ -18,11 +18,11 @@
 </ul>
 <p>If you're trying to view a particular floor, try:
 <ul>
-    <li><a href="{% url 'home' %}floor/g1">{% url 'home' %}floor/g1</a> (to view locations on Gelman, floor 1)
+    <li><a href="{% url 'home' %}gelman/floor/2">{% url 'home' %}gelman/floor/2</a> (to view locations on Gelman, floor 2)
 </ul>
 <p>If you're trying to view statistics on a particular location, try:
 <ul>
-    <li>{% url 'home' %}location/g3/3-005 (to view location 3-101 on Gelman, 3rd floor)
+    <li>{% url 'home' %}/gelman/location/3-101 (to view location 3-101 in Gelman)
 </ul>
 <p>If you're looking to view a particular library's computers using a fixed-width display, try:
 <ul>

--- a/loggins/ui/templates/floor.html
+++ b/loggins/ui/templates/floor.html
@@ -9,6 +9,7 @@
 <table class='table'>
     <thead>
         <tr>
+            <th>Zone</th>
             <th>Station</th>
             <th>Status</th>
             <th>Operating System</th>
@@ -17,7 +18,8 @@
     <tbody>
         {% for location in locations %}
         <tr>
-            <td>{{location.station_name}}</a></td>
+            <td>{{location.zonename}}</td>
+            <td><a href="{% url 'location' library=building station=location.station_name %}">{{location.station_name}}</a></td>
             <td>{{location.state_display}}</td>
             <td>{{location.os_display}}</td>
         </tr>

--- a/loggins/ui/templates/home.html
+++ b/loggins/ui/templates/home.html
@@ -47,9 +47,9 @@
 {% if fixedwidth == 0 %}
 <h4>Show: 
 {% if library_filter != "All" %}<a href="{% url 'home' %}">All</a> / {% endif %}
-{% if library_filter != "Gelman" %}<a href="{% url 'gelman-home' %}">Gelman</a> / {% endif %}
-{% if library_filter != "Eckles" %}<a href="{% url 'eckles-home' %}">Eckles</a> {% if library_filter != "VSTC" %} / {% endif %}{% endif %}
-{% if library_filter != "VSTC" %}<a href="{% url 'vstc-home' %}">VSTC</a>{% endif %}
+{% if library_filter != "Gelman" %}<a href="{% url 'home' library='gelman'%}">Gelman</a> / {% endif %}
+{% if library_filter != "Eckles" %}<a href="{% url 'home' library='eckles'%}">Eckles</a> {% if library_filter != "VSTC" %} / {% endif %}{% endif %}
+{% if library_filter != "VSTC" %}<a href="{% url 'home' library='vstc'%}">VSTC</a>{% endif %}
 </h4>
 {% endif %}
 <h4>

--- a/loggins/ui/templates/home.html
+++ b/loggins/ui/templates/home.html
@@ -17,11 +17,13 @@
     </thead>
     <tbody>
         {% for zone in zones %}
+        {% if zone.num_total_win > 0 or zone.num_total_mac > 0 %}
         <tr>
             <td><a href="{% url 'floor' library=zone.building_display floor_number=zone.floor_number %}">{% if library_filter == "All" %}{{ zone.building_display}}, {% endif %}{{zone.zone_display }}</a></td>
             <td>{% if zone.num_total_win > 0 %}{{zone.num_available_win}} of {{zone.num_total_win}}{% endif %}</td>
             <td>{% if zone.num_total_mac > 0 %}{{zone.num_available_mac}} of {{zone.num_total_mac}}{% endif %}</td>
         </tr>
+        {% endif %}
         {% endfor %}
     </tbody>
 </table>

--- a/loggins/ui/templates/home.html
+++ b/loggins/ui/templates/home.html
@@ -6,7 +6,7 @@
 <div class='span12' style="{% if fixedwidth and fixedwidth != 0 %}width:{{fixedwidth|add:"-10"}}px;margin-left:10px{% endif %}">
     <h1>{% if library_filter == "All" %}
         Library {% else %} {{library_filter|capfirst}} library {% endif %} workstations available</h1>
-{% if buildingfloors %}
+{% if zones %}
 <table class='table tight-table' style="{% if fixedwidth and fixedwidth != 0 %}width:{{fixedwidth|add:"-10"}}px{% endif %}">
     <thead>
         <tr>
@@ -16,11 +16,11 @@
         </tr>
     </thead>
     <tbody>
-        {% for buildingfloor in buildingfloors %}
+        {% for zone in zones %}
         <tr>
-            <td><a href="{% url 'floor' buildingfloor.buildingfloorcode %}">{% if library_filter == "All" %}{{ buildingfloor.building_display}}, {% endif %}{{buildingfloor.floor_display }}</a></td>
-            <td>{% if buildingfloor.num_total_win > 0 %}{{buildingfloor.num_available_win}} of {{buildingfloor.num_total_win}}{% endif %}</td>
-            <td>{% if buildingfloor.num_total_mac > 0 %}{{buildingfloor.num_available_mac}} of {{buildingfloor.num_total_mac}}{% endif %}</td>
+            <td><a href="{% url 'floor' zone.buildingfloorcode %}">{% if library_filter == "All" %}{{ zone.building_display}}, {% endif %}{{zone.zone_display }}</a></td>
+            <td>{% if zone.num_total_win > 0 %}{{zone.num_available_win}} of {{zone.num_total_win}}{% endif %}</td>
+            <td>{% if zone.num_total_mac > 0 %}{{zone.num_available_mac}} of {{zone.num_total_mac}}{% endif %}</td>
         </tr>
         {% endfor %}
     </tbody>

--- a/loggins/ui/templates/home.html
+++ b/loggins/ui/templates/home.html
@@ -18,7 +18,7 @@
     <tbody>
         {% for zone in zones %}
         <tr>
-            <td><a href="{% url 'floor' zone.buildingfloorcode %}">{% if library_filter == "All" %}{{ zone.building_display}}, {% endif %}{{zone.zone_display }}</a></td>
+            <td><a href="{% url 'floor' library=zone.building_display floor_number=zone.floor_number %}">{% if library_filter == "All" %}{{ zone.building_display}}, {% endif %}{{zone.zone_display }}</a></td>
             <td>{% if zone.num_total_win > 0 %}{{zone.num_available_win}} of {{zone.num_total_win}}{% endif %}</td>
             <td>{% if zone.num_total_mac > 0 %}{{zone.num_available_mac}} of {{zone.num_total_mac}}{% endif %}</td>
         </tr>

--- a/loggins/ui/templates/location.html
+++ b/loggins/ui/templates/location.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 <div class='span12'>
-    <h1>History for {{ location.station_name }} on {{bldgname}}, {{floorname}}</h1>
+    <h1>History for {{ location.station_name }} on {{bldgname}}, {{zone}}</h1>
 
 {% if sessions %}
 {% if paginator.num_pages > 1 %}
@@ -27,6 +27,7 @@
 {% endif %}
 <table class='table'>
     <thead>
+        <th>type</th>
         <th>start</th>
         <th>end</th>
         <th>duration (min)</th>
@@ -34,8 +35,9 @@
     <tbody>
         {% for session in sessions %}
         <tr>
-            <td>{{ session.timestamp_login|date:"Y-m-d D H:i:s" }}</td>
-            <td>{{ session.timestamp_logout|date:"Y-m-d D H:i:s" }}</td>
+            <td>{{ session.session_type }}</td>
+            <td>{{ session.timestamp_start|date:"Y-m-d D H:i:s" }}</td>
+            <td>{{ session.timestamp_end|date:"Y-m-d D H:i:s" }}</td>
             <td>{{ session.duration_minutes }}</td>
         </tr>
         {% endfor %}

--- a/loggins/ui/templates/location.html
+++ b/loggins/ui/templates/location.html
@@ -30,15 +30,15 @@
         <th>type</th>
         <th>start</th>
         <th>end</th>
-        <th>duration (min)</th>
+        <th>duration</th>
     </thead>
     <tbody>
         {% for session in sessions %}
         <tr>
-            <td>{{ session.session_type }}</td>
+            <td>{{ session.session_type_display }}</td>
             <td>{{ session.timestamp_start|date:"Y-m-d D H:i:s" }}</td>
             <td>{{ session.timestamp_end|date:"Y-m-d D H:i:s" }}</td>
-            <td>{{ session.duration_minutes }}</td>
+            <td>{{ session.duration }}</td>
         </tr>
         {% endfor %}
     </tbody>

--- a/loggins/ui/templates/offline.html
+++ b/loggins/ui/templates/offline.html
@@ -5,11 +5,11 @@
 {% block content %}
 <div class='span12'>
 {% if locations %}
-<h1>Offline workstations in {{building}}</h1>
+<h1>Offline workstations{% if building %} in {{building}}{% endif %}</h1>
 <table class='table'>
     <thead>
         <tr>
-            <th>Floor</th>
+            <th></th>
             <th>Station</th>
             <th>Operating System</th>
             <th>Offline Since</th>
@@ -18,7 +18,7 @@
     <tbody>
         {% for location in locations %}
         <tr>
-            <td>{{location.floorname}}</td>
+            <td>{% if not building %}{{location.building}} {% endif %}{{location.zonename}}</td>
             <td>{{location.station_name}}</a></td>
             <td>{{location.os_display}}</td>
             <td>{{location.offlinesince}}</td>

--- a/loggins/ui/views.py
+++ b/loggins/ui/views.py
@@ -76,13 +76,11 @@ def location(request, library, station):
     # TODO: Need to gracefully handle condition where len(l) = 0
     location = locations[0]
     sessions = Session.objects.filter(location=location)
-    building = _get_original_string_from_list(
-        library, map(str, Building.objects.values_list('name', flat=True)))
-    # get building name and floor verbage for this building/floor
+
     return render(request, 'location.html', {
         'title': 'Station %s - GW Libraries' % station,
         'zone': location.zone.name,
-        'bldgname': building,
+        'bldgname': str(location.zone.floor.building.name),
         'location': location,
         'floor': location.zone.floor.floor,
         'sessions': sessions,

--- a/loggins/ui/views.py
+++ b/loggins/ui/views.py
@@ -58,7 +58,6 @@ def home(request, library, width=0):
         z['num_available_mac'] = locations_mac_available.count()
         #TODO: Remove this after eliminating dependencies
         zonelist.append(z)
-        print(z)
 
     return render(request, 'home.html', {
         'title': 'Computers Available %s - GW Libraries' % library_title,


### PR DESCRIPTION
Rewrote data model and all dependent code.  This is a large pull request.

Before:
  Location had .building ('g', 'e', or 'v') and .floor (integer).

After:
  New model entities for Building, Floor, Zone.   Buildings have Floors, Floors have Zones, and Zones have Locations.

URL patterns have also changed (hopefully for the better).  Examples:
  /gelman/floor/2 - all locations on a floor
  /gelman/location/E-001  - session history on a location
  /gelman/offline - offline machines in Gelman
  /offline - all offline machines
Currently there is no view for a Zone.

Data migration:
  0004 - adds new entities
  0005 - custom data migration.  First, this adds GW-Libraries specific Buildings, Floors, and Zones.  Then it migrates existing Locations by associating each with the appropriate Zone, by parsing the location naming schema.
  0006 - removes obsolete Location fields
