### PR TITLE
/sign view changes to fit with new frame and colors in library digital signage

### DIFF
--- a/loggins/ui/static/css/loggins-fixed.css
+++ b/loggins/ui/static/css/loggins-fixed.css
@@ -2,11 +2,18 @@ article {
     padding-top: 3em;
     padding-bottom: 0em;
     min-height: 0;
+    background-color: #d9e1e2;
 }
 .tight-table td, .tight-table th {
     line-height: 28px;
     padding: 6px 8px 0 0;
     font-size: 142%;
+}
+.value-column {
+    color: #004065;
+}
+.header-column {
+    color: #0096d6;
 }
 h1 {
     font-size: 175%;

--- a/loggins/ui/templates/base.html
+++ b/loggins/ui/templates/base.html
@@ -48,18 +48,17 @@ ga('send', 'pageview');
         {% endblock analytics_bug %}
     </head>
     <body>
+        {% if not fixedwidth or fixedwidth == 0 %}
         <!-- this is the Libsite7 Lite Header -->
         <header class="navbar-fixed-top">
-            <div id="libheader-container" style="{% if fixedwidth and fixedwidth != 0 %}width:{{fixedwidth}}px{% endif %}">
+            <div id="libheader-container">
                 <div id="libheader" class="container" style="">
                     <div class="libheader-logo hide-lo" style="">
                         <a href="http://www.gwu.edu" target="_blank" title="GWU website"><img src="{{ STATIC_URL }}img/gwheaderlogo.png" alt="logo: The George Washington University" /></a>
                     </div>
-                    {% if not fixedwidth or fixedwidth == 0 %}
                     <div class="libheader-liblink" style="">
                         <a href="http://library.gwu.edu" target="_blank" title="GW Libraries website">GW Libraries</a>
                     </div>
-                    {% endif %}
                     <div class="libheader-link" style="">
                         <a href="{% url 'home' %}" title="computers.library.gwu.edu home">computers.library.gwu.edu</a>
                     </div>
@@ -71,6 +70,7 @@ ga('send', 'pageview');
             </div>
         </header>
         <!-- end Libsite7 Lite Header -->
+        {% endif %}
 
         <article class='container' style="{% if fixedwidth and fixedwidth != 0 %}width:{{fixedwidth}}px;margin-left:0{% endif %}">
             <div class="row-fluid">
@@ -80,10 +80,11 @@ ga('send', 'pageview');
         </article>
 
         <!-- the Libsite7 Lite Footer -->
-        <footer class="navbar-fixed-bottom" style="{% if fixedwidth and fixedwidth != 0 %}position:absolute;bottom:0;width:{{fixedwidth}}px;padding-right:0{% endif %}">
+        {% if fixedwidth == 0 %}
+        <footer class="navbar-fixed-bottom">
             <div id="libfooter-container" style="width:100%">
                 <div id="libfooter" class="container" style="width:100%">
-                    <div class="libfooter-text" style="{% if fixedwidth and fixedwidth and fixedwidth != 0 %}display:none{% endif %}">
+                    <div class="libfooter-text">
                         <span class="address">
                             <a href="http://library.gwu.edu" target="_blank" title="GW Libraries Website">GW Libraries</a> 
                             &#8226; 2130 H Street NW &#8226; Washington DC 20052
@@ -96,6 +97,7 @@ ga('send', 'pageview');
                 </div>
             </div>
         </footer>
+        {% endif %}
         <!-- end Libsite7 Lite Footer -->
 
     </body>

--- a/loggins/ui/templates/home.html
+++ b/loggins/ui/templates/home.html
@@ -3,25 +3,31 @@
 {% load humanize %}
 
 {% block content %}
-<div class='span12' style="{% if fixedwidth and fixedwidth != 0 %}width:{{fixedwidth|add:"-10"}}px;margin-left:10px{% endif %}">
+<div class='span12' style="{% if fixedwidth and fixedwidth != 0 %}width:{{fixedwidth|add:"-10"}}px;margin-left:5px{% endif %}">
+{% if fixedwidth == 0 %}
     <h1>{% if library_filter == "All" %}
         Library {% else %} {{library_filter|capfirst}} Library {% endif %} workstations available</h1>
+{% endif %}
 {% if zones %}
 <table class='table tight-table' style="{% if fixedwidth and fixedwidth != 0 %}width:{{fixedwidth|add:"-10"}}px{% endif %}">
     <thead>
         <tr>
             <th>Floor</th>
-            <th>Windows</th>
-            <th>Mac</th>
+            <th style="text-align: center">Windows</th>
+            <th style="text-align: center">Mac</th>
         </tr>
     </thead>
     <tbody>
         {% for zone in zones %}
         {% if zone.num_total_win > 0 or zone.num_total_mac > 0 %}
         <tr>
-            <td><a href="{% url 'floor' library=zone.building_display floor_number=zone.floor_number %}">{% if library_filter == "All" %}{{ zone.building_display}}, {% endif %}{{zone.zone_display }}</a></td>
-            <td>{% if zone.num_total_win > 0 %}{{zone.num_available_win}}&nbsp;of&nbsp;{{zone.num_total_win}}{% endif %}</td>
-            <td>{% if zone.num_total_mac > 0 %}{{zone.num_available_mac}}&nbsp;of&nbsp;{{zone.num_total_mac}}{% endif %}</td>
+            {% if fixedwidth == 0 %}
+            <td class='header-column'><a href="{% url 'floor' library=zone.building_display floor_number=zone.floor_number %}">{% if library_filter == "All" %}{{ zone.building_display}}, {% endif %}{{zone.zone_display }}</a></td>
+            {% else %}
+            <td class='header-column'>{% if library_filter == "All" %}{{ zone.building_display}}, {% endif %}{{zone.zone_display }}</td>
+            {% endif %}
+            <td class='value-column' style="text-align: center">{% if zone.num_total_win > 0 %}{{zone.num_available_win}}&nbsp;of&nbsp;{{zone.num_total_win}}{% endif %}</td>
+            <td class='value-column' style="text-align: center">{% if zone.num_total_mac > 0 %}{{zone.num_available_mac}}&nbsp;of&nbsp;{{zone.num_total_mac}}{% endif %}</td>
         </tr>
         {% endif %}
         {% endfor %}
@@ -53,11 +59,9 @@
 {% if library_filter != "Eckles" %}<a href="{% url 'home' library='eckles'%}">Eckles</a> {% if library_filter != "VSTC" %} / {% endif %}{% endif %}
 {% if library_filter != "VSTC" %}<a href="{% url 'home' library='vstc'%}">VSTC</a>{% endif %}
 </h4>
-{% endif %}
 <h4>
 Last updated on {% now "DATETIME_FORMAT"%}
 </h4>
-{% if fixedwidth == 0 %}
 <h4>
 <a href="http://library.gwu.edu/services/computers-wireless/library-computers">About GW Libraries Computers</a>
 </div>


### PR DESCRIPTION
Fixes #198, fixes #197, fixes #194:  Increased left margin back to 5px, hide header and footer for fixed-width view (for /sign), uses GW Print colors for sign view, removes hyperlinks from /sign view home page, removes everything but the table for /sign view (e.g. header and footer, etc.)
